### PR TITLE
added a single API to fetch all the data for task groups

### DIFF
--- a/backend/server/controllers/task_assign_controller.py
+++ b/backend/server/controllers/task_assign_controller.py
@@ -11,6 +11,15 @@ class ReportAssignmentResponse(BaseModel):
     report_id: str
     assigned_challenge_ids: List[int]
 
+class TaskGroupDetailsResponse(BaseModel):
+    reportId: str
+    reportTopic: str
+    progress: float
+    taskCount: int
+    completedCount: int
+    pendingCount: int
+    tasks: dict
+
 # API endpoint to assign challenges to a report
 @router.post("/assign_challenges", response_model=ReportAssignmentResponse)
 async def assign_challenges_endpoint(report_id: str, user_id: str = Depends(get_current_user_id)):
@@ -43,38 +52,6 @@ def fetch_task_group_count(user_id: str = Depends(get_current_user_id)):
     except Exception as e:
         logging.error(f"Error in /report_count: {e}")
         raise HTTPException(status_code=500, detail=str(e))
-    
-@router.get("/report/task_count")
-def fetch_task_count(
-    report_id: str = Query(..., description="reportId to count tasks"),
-    user_id: str = Depends(get_current_user_id)):
-
-    try:
-        # Verify user has access to this report
-        if not user_has_access_to_report(report_id, user_id):
-            raise HTTPException(status_code=403, detail="You don't have access to this report")
-            
-        task_count = get_task_count(report_id)
-        return {"reportId": report_id, "taskCount": task_count}
-    except Exception as e:
-        logging.error(f"Error in /report/task_count: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-    
-@router.get("/report/progress")
-def fetch_task_group_progress(
-    report_id: str = Query(..., description="Report ID for the task group"),
-    user_id: str = Depends(get_current_user_id)):
-
-    try:
-        # Verify user has access to this report
-        if not user_has_access_to_report(report_id, user_id):
-            raise HTTPException(status_code=403, detail="You don't have access to this report")
-            
-        progress = get_task_group_progress(report_id)
-        return {"reportId": report_id, "progressPercentage": progress}
-    except Exception as e:
-        logging.error(f"Error in /report/progress: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/overall-progress")
 def fetch_overall_progress(user_id: str = Depends(get_current_user_id)):
@@ -84,77 +61,11 @@ def fetch_overall_progress(user_id: str = Depends(get_current_user_id)):
     except Exception as e:
         logging.error(f"Error in /overall-progress: {e}")
         raise HTTPException(status_code=500, detail=str(e))
-    
-# API endpoint to fetch the tasks
-@router.get("/report/task/all")
-def fetch_all_tasks(
-    report_id: str = Query(..., description="Report ID to fetch all tasks"),
-    user_id: str = Depends(get_current_user_id)):
 
-    try:
-        # Verify user has access to this report
-        if not user_has_access_to_report(report_id, user_id):
-            raise HTTPException(status_code=403, detail="You don't have access to this report")
-            
-        tasks = get_tasks(report_id)
-        return {"reportId": report_id, "tasks": tasks}
-    except Exception as e:
-        logging.error(f"Error in /report/task/all: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-@router.get("/report/task/todo")
-def fetch_todo_tasks(
-    report_id: str = Query(..., description="Report ID to fetch tasks to do"),
-    user_id: str = Depends(get_current_user_id)):
-
-    try:
-        # Verify user has access to this report
-        if not user_has_access_to_report(report_id, user_id):
-            raise HTTPException(status_code=403, detail="You don't have access to this report")
-            
-        tasks = get_tasks(report_id)
-        todo_tasks = [task for task in tasks if not task.get("isDone")]
-        return {"reportId": report_id, "tasks": todo_tasks}
-    except Exception as e:
-        logging.error(f"Error in /report/task/todo: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-@router.get("/report/task/completed")
-def fetch_completed_tasks(
-    report_id: str = Query(..., description="Report ID to fetch completed tasks"),
-    user_id: str = Depends(get_current_user_id)):
-
-    try:
-        # Verify user has access to this report
-        if not user_has_access_to_report(report_id, user_id):
-            raise HTTPException(status_code=403, detail="You don't have access to this report")
-            
-        tasks = get_tasks(report_id)
-        completed_tasks = [task for task in tasks if task.get("isDone")]
-        return {"reportId": report_id, "tasks": completed_tasks}
-    except Exception as e:
-        logging.error(f"Error in /report/task/completed: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-@router.get("/report/completed_count")
-def fetch_completed_challenge_count(
-    report_id: str = Query(..., description="Report ID to count completed challenges"),
-    user_id: str = Depends(get_current_user_id)):
-
-    try:
-        # Verify user has access to this report
-        if not user_has_access_to_report(report_id, user_id):
-            raise HTTPException(status_code=403, detail="You don't have access to this report")
-            
-        completed_count = get_challenge_count_by_status(report_id, is_done=True)
-        return completed_count
-    except Exception as e:
-        logging.error(f"Error in /report/completed_count: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
-
-@router.get("/report/pending_count")
-def fetch_pending_challenge_count(
-    report_id: str = Query(..., description="Report ID to count pending challenges"),
+# Consolidated API endpoint to get all details for a task group
+@router.get("/report/details", response_model=TaskGroupDetailsResponse)
+def get_task_group_details_endpoint(
+    report_id: str = Query(..., description="Report ID to fetch all details"),
     user_id: str = Depends(get_current_user_id)):
     
     try:
@@ -162,8 +73,8 @@ def fetch_pending_challenge_count(
         if not user_has_access_to_report(report_id, user_id):
             raise HTTPException(status_code=403, detail="You don't have access to this report")
             
-        pending_count = get_challenge_count_by_status(report_id, is_done=False)
-        return pending_count
+        task_group_details = get_task_group_details(report_id)
+        return task_group_details
     except Exception as e:
-        logging.error(f"Error in /report/pending_count: {e}")
+        logging.error(f"Error in /report/details: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/flutter_app/lib/services/task_assign/task_group_service.dart
+++ b/frontend/flutter_app/lib/services/task_assign/task_group_service.dart
@@ -30,6 +30,37 @@ class TaskGroupService {
     return supabase.auth.currentSession?.accessToken;
   }
 
+  // Fetch detailed information for a specific task group
+  Future<Map<String, dynamic>> getTaskGroupDetails(String reportId) async {
+    try {
+      final token = getAuthToken();
+      if (token == null) {
+        throw Exception('Authentication required');
+      }
+
+      final response = await http.get(
+        Uri.parse('$baseUrl/report/details?report_id=$reportId'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+      );
+
+      print('Response status for details: ${response.statusCode}');
+
+      if (response.statusCode == 200) {
+        return jsonDecode(response.body);
+      } else {
+        print('Error from server: ${response.body}');
+        throw Exception('Server error: ${response.statusCode}');
+      }
+    } catch (e) {
+      print('Error fetching task group details: $e');
+      throw Exception('Failed to fetch task group details: $e');
+    }
+  }
+
   // Fetch task groups from backend
   Future<List<TaskGroup>> getTaskGroups() async {
     try {
@@ -55,7 +86,6 @@ class TaskGroupService {
       );
 
       print('Response status: ${response.statusCode}');
-      print('Response body: ${response.body}');
 
       if (response.statusCode == 200) {
         List<dynamic> data = jsonDecode(response.body);
@@ -65,69 +95,40 @@ class TaskGroupService {
         for (var item in data) {
           final reportId = item['Id'];
 
-          // Get task count for this report
-          int taskCount = 0;
-          double progress = 0.0;
-          List<Task> tasks = [];
-
           if (token != null) {
-            // Only fetch additional details if authenticated
+            // Use the new consolidated API endpoint
             try {
-              // Get task count
-              final taskCountResponse = await http.get(
-                Uri.parse('$baseUrl/report/task_count?report_id=$reportId'),
-                headers: {'Authorization': 'Bearer $token'},
-              );
-              if (taskCountResponse.statusCode == 200) {
-                var taskCountData = jsonDecode(taskCountResponse.body);
-                taskCount = taskCountData['taskCount'] ?? 0;
-              }
+              final taskGroupDetails = await getTaskGroupDetails(reportId);
 
-              // Get progress percentage
-              final progressResponse = await http.get(
-                Uri.parse('$baseUrl/report/progress?report_id=$reportId'),
-                headers: {'Authorization': 'Bearer $token'},
-              );
-              if (progressResponse.statusCode == 200) {
-                var progressData = jsonDecode(progressResponse.body);
-                progress = (progressData['progressPercentage'] ?? 0.0) / 100;
-              }
+              // Convert tasks from API response format to Task objects
+              List<dynamic> allTasks = taskGroupDetails['tasks']['all'] ?? [];
+              List<Task> tasks = allTasks
+                  .map((task) => Task(
+                        title: task['title'] ?? "",
+                        isCompleted: task['isDone'] ?? false,
+                      ))
+                  .toList();
 
-              // Get tasks
-              final tasksResponse = await http.get(
-                Uri.parse('$baseUrl/report/task/all?report_id=$reportId'),
-                headers: {'Authorization': 'Bearer $token'},
-              );
-              if (tasksResponse.statusCode == 200) {
-                var tasksData = jsonDecode(tasksResponse.body);
-                List<dynamic> tasksList = tasksData['tasks'] ?? [];
-                tasks = tasksList
-                    .map((task) => Task(
-                          title: task['title'] ?? "",
-                          isCompleted: task['isDone'] ?? false,
-                        ))
-                    .toList();
-              }
+              taskGroups.add(TaskGroup(
+                title: taskGroupDetails['reportTopic'] ?? "Untitled Group",
+                taskCount: taskGroupDetails['taskCount'] ?? 0,
+                progress: (taskGroupDetails['progress'] ?? 0.0) / 100,
+                tasks: tasks,
+                reportId: reportId,
+              ));
             } catch (e) {
               print('Error fetching details for report $reportId: $e');
             }
           } else {
-            // Use mock data if not authenticated
-            taskCount = 5;
-            progress = 0.5;
-            tasks = [
-              Task(title: "Sample Task 1", isCompleted: true),
-              Task(title: "Sample Task 2", isCompleted: false),
-            ];
+            // When not authenticated, just add basic info
+            taskGroups.add(TaskGroup(
+              title: item['Topic'] ?? "Untitled Group",
+              taskCount: 0,
+              progress: 0.0,
+              tasks: [],
+              reportId: reportId,
+            ));
           }
-
-          taskGroups.add(TaskGroup(
-            title: item['Topic'] ?? "Untitled Group",
-            taskCount: taskCount,
-            progress: progress,
-            tasks: tasks,
-            reportId: reportId,
-          ));
         }
 
         return taskGroups;
@@ -137,93 +138,80 @@ class TaskGroupService {
       }
     } catch (e) {
       print('Error fetching task groups: $e');
-      // Return mock data instead of throwing an exception
-      return _getMockTaskGroups();
+      throw Exception('Failed to load task groups: $e');
     }
   }
 
-  // Method to provide mock data
-  List<TaskGroup> _getMockTaskGroups() {
-    print('Returning mock task groups');
-    return [
-      TaskGroup(
-        title: "Machine Learning (Mock)",
-        taskCount: 4,
-        progress: 0.65,
-        tasks: [
-          Task(title: "Power Pose Challenge", isCompleted: true),
-          Task(title: "Smooth Steady Stare", isCompleted: false),
-          Task(title: "Smooth Talker", isCompleted: false),
-          Task(title: "Filler Free Zone", isCompleted: false),
-        ],
-      ),
-      TaskGroup(
-        title: "Psychology Traits (Mock)",
-        taskCount: 6,
-        progress: 0.50,
-        tasks: [
-          Task(title: "Confidence Builder", isCompleted: true),
-          Task(title: "Eye Contact Master", isCompleted: false),
-          Task(title: "Voice Projection", isCompleted: false),
-          Task(title: "Audience Engagement", isCompleted: false),
-          Task(title: "Gesture Control", isCompleted: false),
-          Task(title: "Pacing Practice", isCompleted: false),
-        ],
-      ),
-      TaskGroup(
-        title: "Development Behavior (Mock)",
-        taskCount: 5,
-        progress: 0.40,
-        tasks: [
-          Task(title: "Structure Planning", isCompleted: true),
-          Task(title: "Opening Hook", isCompleted: false),
-          Task(title: "Closing Impact", isCompleted: false),
-          Task(title: "Visual Aid Mastery", isCompleted: false),
-          Task(title: "Q&A Preparation", isCompleted: false),
-        ],
-      ),
-    ];
-  }
-
+  // Get tasks for a specific group - now using the consolidated API
   Future<List<Task>> getTasksForGroup(String reportId) async {
     try {
       final token = getAuthToken();
       if (token == null) {
-        return _getMockTasksForGroup();
+        throw Exception('Authentication required');
       }
 
-      final response = await http.get(
-        Uri.parse('$baseUrl/report/task/all?report_id=$reportId'),
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer $token',
-        },
-      );
+      // Use the new consolidated endpoint
+      final details = await getTaskGroupDetails(reportId);
+      List<dynamic> tasksList = details['tasks']['all'] ?? [];
 
-      if (response.statusCode == 200) {
-        var data = jsonDecode(response.body);
-        List<dynamic> tasksList = data['tasks'] ?? [];
-        return tasksList
-            .map((task) => Task(
-                  title: task['title'] ?? "",
-                  isCompleted: task['isDone'] ?? false,
-                ))
-            .toList();
-      } else {
-        throw Exception('Failed to load tasks');
-      }
+      return tasksList
+          .map((task) => Task(
+                title: task['title'] ?? "",
+                isCompleted: task['isDone'] ?? false,
+              ))
+          .toList();
     } catch (e) {
       print('Error fetching tasks: $e');
-      return _getMockTasksForGroup();
+      throw Exception('Failed to load tasks: $e');
     }
   }
 
-  List<Task> _getMockTasksForGroup() {
-    return [
-      Task(title: "Mock Task 1", isCompleted: true),
-      Task(title: "Mock Task 2", isCompleted: false),
-      Task(title: "Mock Task 3", isCompleted: false),
-    ];
+  // Get todo tasks for a specific group
+  Future<List<Task>> getTodoTasksForGroup(String reportId) async {
+    try {
+      final token = getAuthToken();
+      if (token == null) {
+        throw Exception('Authentication required');
+      }
+
+      // Use the new consolidated endpoint
+      final details = await getTaskGroupDetails(reportId);
+      List<dynamic> tasksList = details['tasks']['todo'] ?? [];
+
+      return tasksList
+          .map((task) => Task(
+                title: task['title'] ?? "",
+                isCompleted: false,
+              ))
+          .toList();
+    } catch (e) {
+      print('Error fetching todo tasks: $e');
+      throw Exception('Failed to load todo tasks: $e');
+    }
+  }
+
+  // Get completed tasks for a specific group
+  Future<List<Task>> getCompletedTasksForGroup(String reportId) async {
+    try {
+      final token = getAuthToken();
+      if (token == null) {
+        throw Exception('Authentication required');
+      }
+
+      // Use the new consolidated endpoint
+      final details = await getTaskGroupDetails(reportId);
+      List<dynamic> tasksList = details['tasks']['completed'] ?? [];
+
+      return tasksList
+          .map((task) => Task(
+                title: task['title'] ?? "",
+                isCompleted: true,
+              ))
+          .toList();
+    } catch (e) {
+      print('Error fetching completed tasks: $e');
+      throw Exception('Failed to load completed tasks: $e');
+    }
   }
 
   Future<bool> updateTaskStatus(


### PR DESCRIPTION
added a single API to fetch all the data for the task groups instead of calling several APIs for every single value such as the task group name, task count, etc. Removed the unnecessary API endpoints in controller file and unnecessary functions in service file. Removed mock data that was hardcoded on task_group_service. 

@Chamod07 if possible merge into main before updating the frontend for task group page.