### PR TITLE
Link uploaded videos to specific reports

### DIFF
--- a/backend/server/controllers/report_controller.py
+++ b/backend/server/controllers/report_controller.py
@@ -56,3 +56,29 @@ async def get_complete_report(
     except Exception as e:
         logging.error(f"Error fetching complete report: {e}")
         raise HTTPException(status_code=500, detail=f"Error retrieving report data: {str(e)}")
+
+@router.get("/video")
+async def get_report_video(
+    report_id: str = Query(..., description="Report ID"), 
+    user_id: str = Depends(get_current_user_id)
+):
+    """
+    Get the video URL for a specific report
+    """
+    try:
+        # Verify user has access to this report
+        from services.task_assign_service import user_has_access_to_report
+        if not user_has_access_to_report(report_id, user_id):
+            raise HTTPException(status_code=403, detail="You don't have access to this report")
+        
+        # Fetch the video URL
+        response = storage_service.supabase.table("UserReport").select("videoUrl").eq("reportId", report_id).execute()
+        
+        if not response.data or not response.data[0].get("videoUrl"):
+            raise HTTPException(status_code=404, detail="No video found for this report")
+        
+        return {"videoUrl": response.data[0]["videoUrl"]}
+        
+    except Exception as e:
+        logging.error(f"Error fetching video URL: {e}")
+        raise HTTPException(status_code=500, detail=f"Error retrieving video URL: {str(e)}")

--- a/backend/server/models/user_report_model.py
+++ b/backend/server/models/user_report_model.py
@@ -19,3 +19,4 @@ class UserReport(BaseReport):
     scoreVoice: Optional[float] = None
     resources: Optional[Dict[str, Any]] = None
     feedback: Optional[Dict[str, Any]] = None
+    videoUrl: Optional[str] = None

--- a/backend/server/routers/upload.py
+++ b/backend/server/routers/upload.py
@@ -1,13 +1,21 @@
-from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
-from services.storage_service import upload_to_supabase
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends, Query
+from services.storage_service import upload_to_supabase, get_video_public_url
 from .auth import get_current_user
+from services import storage_service
 
 router = APIRouter()
 
 @router.post("/upload/")
-async def upload_video(file: UploadFile = File(...), user = Depends(get_current_user)):
+async def upload_video(
+    file: UploadFile = File(...),
+    report_id: str = Query(..., description="Report ID to link the video to"),
+    user = Depends(get_current_user)
+):
     if file.content_type not in ["video/mp4", "video/mov"]:
         raise HTTPException(status_code=400, detail="Invalid file type")
+    
+    # Generate a unique filename using report_id
+    filename = f"{report_id}/{file.filename}"
     
     # Save file temporarily
     temp_file_path = f"/tmp/{file.filename}"
@@ -15,7 +23,27 @@ async def upload_video(file: UploadFile = File(...), user = Depends(get_current_
         temp_file.write(await file.read())
 
     # Upload to Supabase
-    supabase_url = upload_to_supabase(temp_file_path, file.filename)
-
-    return {"message": "File uploaded successfully", "url": supabase_url}
+    bucket_name = "videos"
+    path = f"users/{user.id}/{filename}"
     
+    # Upload the file
+    supabase_url = upload_to_supabase(temp_file_path, path, bucket_name)
+    
+    # Get the public URL
+    public_url = get_video_public_url(bucket_name, path)
+    
+    # Update the UserReport record with the video URL
+    try:
+        response = storage_service.supabase.table("UserReport").update({
+            "videoUrl": public_url
+        }).eq("reportId", report_id).execute()
+        
+        if response.error:
+            raise HTTPException(status_code=500, detail=f"Error updating report: {response.error}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error linking video to report: {str(e)}")
+
+    return {
+        "message": "File uploaded successfully and linked to report",
+        "url": public_url
+    }

--- a/backend/server/services/storage_service.py
+++ b/backend/server/services/storage_service.py
@@ -16,3 +16,10 @@ def upload_to_supabase(file_path: str, filename: str) -> str:
 
     public_url = supabase.storage.from_(STORAGE_BUCKET_NAME).get_public_url(filename)
     return public_url
+
+def get_video_public_url(bucket_name: str, path: str) -> str:
+    """
+    Get the public URL for a file in Supabase storage
+    """
+    response = supabase.storage.from_(bucket_name).get_public_url(path)
+    return response


### PR DESCRIPTION
### Enhancements to video processing and storage:

* [`backend/server/controllers/main_process_controller.py`](diffhunk://#diff-78cb338d959583e95f9e0173403f5547238c813badf4811bd4a30259102cc935L1-R21): Added user authentication to the `process_video` endpoint and modified the function to fetch the video URL from the report.
* [`backend/server/controllers/report_controller.py`](diffhunk://#diff-61dd3eb7878aa9861126e416f403f84c59e3339ece8eb039a33e21361e1edaf4R59-R84): Introduced a new endpoint `get_report_video` to fetch the video URL for a specific report, with user access verification.
* [`backend/server/models/user_report_model.py`](diffhunk://#diff-5948e0bc4055b38a0c81c4aacccaafec2fa18206005eb11cd39d862753421b42R22): Added a new field `videoUrl` to the `UserReport` model to store the video URL.
* [`backend/server/routers/upload.py`](diffhunk://#diff-d17f88744fb16f473a6242fb716a37534e354ba348ea0cebfb91ebe06035dea4L1-R49): Enhanced the `upload_video` endpoint to link the uploaded video to a report and update the `UserReport` record with the video URL.

### New utility function:

* [`backend/server/services/storage_service.py`](diffhunk://#diff-8592099d6b4f7645a24e152f8caea93d64e9e2212bcddbc587ef8c915e025865R19-R25): Added a new function `get_video_public_url` to retrieve the public URL for a file in Supabase storage upon upload