### PR TITLE
Fetch session ID for video upload and update UserReport with video URL

### DIFF
--- a/frontend/flutter_app/lib/components/camera/camera_function.dart
+++ b/frontend/flutter_app/lib/components/camera/camera_function.dart
@@ -335,13 +335,26 @@ class CameraFunctions {
           return false;
         }
         //fetching report ID from supabase
-        // final response = await SupabaseService().client
-        //   .from('UserReport')
-        //   .select('reportId')
-        //   .eq('userId', userId)
-        //   .single();
+        final response = await SupabaseService().client
+          .from('UserReport')
+          .select('session_id')
+          .eq('userId', userId).order('createdAt', ascending: false).limit(1)
+          .maybeSingle();
 
-        // final reportId = response['reportId'];
+        String? sessionId;
+        if (response != null) {
+          sessionId = response['session_id'];
+        } else {
+          print('No user report found for this user');
+          return false;
+        }
+
+        if (sessionId == null) {
+          print('Session ID is null, cannot upload video');
+          return false;
+        }
+
+        videoMetaData['session_id'] = sessionId;
 
         statusSubscription = UploadService().statusStream.listen((status) {
           // Check for completion status with our recording ID in the message
@@ -359,7 +372,7 @@ class CameraFunctions {
         UploadService().uploadVideo(
           videoFile: videoFile,
           metadata: videoMetaData,
-         // reportId: reportId,
+          sessionId: sessionId,
         );
         print('Video queued for upload: $videoFilePath');
 


### PR DESCRIPTION
Changes to `CameraFunctions`:

* Updated the method to fetch `session_id` instead of `reportId` from Supabase and added error handling for cases where the session ID is not found or is null.
* Modified the `uploadVideo` call to use the `sessionId` instead of `reportId`.

Changes to `UploadService`:

* Changed the `uploadVideo` method to require `sessionId` instead of `reportId`.
* Updated the file path and upload ID generation to use `sessionId` instead of a timestamp.
* Added logic to check for the existence of `session_id` in the `UserReport` table and update the video URL if the session ID exists.