### PR TITLE
Refactor video upload process to use report ID instead of session ID

### DIFF
--- a/frontend/flutter_app/lib/components/camera/camera_function.dart
+++ b/frontend/flutter_app/lib/components/camera/camera_function.dart
@@ -335,26 +335,25 @@ class CameraFunctions {
           return false;
         }
         //fetching report ID from supabase
-        final response = await SupabaseService().client
-          .from('UserReport')
-          .select('session_id')
-          .eq('userId', userId).order('createdAt', ascending: false).limit(1)
-          .maybeSingle();
+        final response = await SupabaseService().client.from('UserReport').select('reportId').eq('userId', userId).order('createdAt', ascending: false).limit(1).maybeSingle();
 
-        String? sessionId;
+
+        String? reportId;
         if (response != null) {
-          sessionId = response['session_id'];
+          reportId = response['reportId'];
         } else {
           print('No user report found for this user');
           return false;
         }
 
-        if (sessionId == null) {
-          print('Session ID is null, cannot upload video');
+
+        if (reportId == null) {
+          print('Report ID is null, cannot upload video');
           return false;
         }
 
-        videoMetaData['session_id'] = sessionId;
+
+        videoMetaData['reportId'] = reportId;
 
         statusSubscription = UploadService().statusStream.listen((status) {
           // Check for completion status with our recording ID in the message
@@ -372,7 +371,7 @@ class CameraFunctions {
         UploadService().uploadVideo(
           videoFile: videoFile,
           metadata: videoMetaData,
-          sessionId: sessionId,
+          reportId: reportId,
         );
         print('Video queued for upload: $videoFilePath');
 

--- a/frontend/flutter_app/lib/services/upload/upload_service.dart
+++ b/frontend/flutter_app/lib/services/upload/upload_service.dart
@@ -69,7 +69,7 @@ class UploadService {
   Future<void> uploadVideo({
     required File videoFile,
     required Map<String, dynamic> metadata,
-    required String sessionId,
+    required String reportId,
   }) async {
     if (!_supabaseService.isInitialized) {
       debugPrint('Error: Supabase is not initialized');
@@ -79,11 +79,10 @@ class UploadService {
 
     // Create a unique upload ID and file path
     final userId = _supabaseService.currentUserId ?? 'anonymous';
-    // final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final folderPath = 'user_${userId}/presentation_${sessionId}';
-    final fileName = '$folderPath/video_${sessionId}.mp4';
+    final folderPath = 'user_${userId}/presentation_${reportId}';
+    final fileName = '$folderPath/video_${reportId}.mp4';
     final metadataFileName = '$folderPath/metadata.json';
-    final uploadId = 'upload_$sessionId';
+    final uploadId = 'upload_$reportId';
 
     // Check if the file needs chunking
     //final needsChunking = await _chunkingService.needsChunking(videoFile);
@@ -263,25 +262,25 @@ class UploadService {
 
       // Get the public URL of the video (or first chunk if chunked)
       final videoUrl = _supabaseService.client.storage.from(bucketName).getPublicUrl(fileName);
-      debugPrint(videoUrl);
-      final sessionId = metadata['session_id'];
+      debugPrint(videoUrl);;
+      final reportId = metadata['reportId'];
 
-      if (sessionId != null) {
+      if (reportId != null) {
         try {
-          debugPrint('Checking if session_id $sessionId exists in UserReport...');
+          debugPrint('Checking if reportId $reportId exists in UserReport...');
 
           // First check if the record with this session_id exists
-          final checkResponse = await Supabase.instance.client.from('UserReport').select('session_id').eq('session_id', sessionId).single();
+          final checkResponse = await Supabase.instance.client.from('UserReport').select('reportId').eq('reportId', reportId).single();
 
           if (checkResponse != null) {
-            debugPrint('Found session_id $sessionId in UserReport, proceeding with update');
+            debugPrint('Found reportId $reportId in UserReport, proceeding with update');
 
             // Get the public URL of the video
             final videoUrl = _supabaseService.client.storage.from(bucketName).getPublicUrl(fileName);
             debugPrint('Generated video URL: $videoUrl');
 
             // Perform the update
-            final response = await Supabase.instance.client.from('UserReport').update({'videoUrl': videoUrl}).eq('session_id', sessionId).select();
+            final response = await Supabase.instance.client.from('UserReport').update({'videoUrl': videoUrl}).eq('reportId', reportId).select();
 
             if (response != null && response.isNotEmpty) {
               debugPrint('Successfully updated UserReport video URL.');
@@ -290,13 +289,13 @@ class UploadService {
               debugPrint('Update query executed but no records were updated in UserReport.');
             }
           } else {
-            debugPrint('Error: No record found with session_id $sessionId in UserReport');
+            debugPrint('Error: No record found with reportId $reportId in UserReport');
           }
         } catch (e) {
           debugPrint('Exception checking/updating UserReport: $e');
         }
       } else {
-        debugPrint('Warning: No sessionId provided in metadata, could not update UserReport');
+        debugPrint('Warning: No reportId provided in metadata, could not update UserReport');
       }
 
       // Create a database record for the upload


### PR DESCRIPTION
This pull request includes significant changes to the `frontend/flutter_app` to replace the usage of `sessionId` with `reportId` in the `CameraFunctions` and `UploadService` classes. These changes ensure consistency and clarity in the codebase.

Changes to `CameraFunctions`:

* Replaced `sessionId` with `reportId` in the Supabase query and subsequent logic for fetching and using report IDs.

Changes to `UploadService`:

* Updated the `uploadVideo` method to use `reportId` instead of `sessionId` for video uploads.
* Modified the logic for creating folder paths, file names, and upload IDs to use `reportId`.
* Adjusted the metadata handling and database update checks to use `reportId` instead of `sessionId`. 