### PR TITLE
Remove overflow error in task_group_page

### DIFF
--- a/frontend/flutter_app/lib/components/tasks/task_group_page.dart
+++ b/frontend/flutter_app/lib/components/tasks/task_group_page.dart
@@ -750,6 +750,7 @@ class _TaskGroupPageState extends State<TaskGroupPage>
           ),
           const SizedBox(height: 25),
           Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               // Enhanced progress bar with animations
               Expanded(
@@ -793,12 +794,18 @@ class _TaskGroupPageState extends State<TaskGroupPage>
                       ],
                     ),
                     const SizedBox(height: 16),
+                    Wrap(
+                      // horizontal spacing
+                      spacing: 8,
+                      // vertical spacing if it wraps
+                      runSpacing: 8,
+                      alignment: WrapAlignment.spaceBetween,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
                     Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         // Percentage with icon
-                        Row(
-                          children: [
                             Container(
                               padding: const EdgeInsets.all(6),
                               decoration: BoxDecoration(
@@ -825,7 +832,7 @@ class _TaskGroupPageState extends State<TaskGroupPage>
                         // Collection count badge
                         Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 4),
+                              horizontal: 8, vertical: 4),
                           decoration: BoxDecoration(
                             color: Colors.white.withOpacity(0.2),
                             borderRadius: BorderRadius.circular(12),
@@ -842,9 +849,9 @@ class _TaskGroupPageState extends State<TaskGroupPage>
                       ],
                     ),
                   ],
+                  ),
                 ),
-              ),
-              const SizedBox(width: 20),
+              const SizedBox(width: 24),
 
               // Enhanced pie chart progress indicator
               _buildEnhancedProgressChart(progress),


### PR DESCRIPTION
This pull request includes several layout and styling improvements to the `TaskGroupPage` component in the Flutter application. The changes enhance the layout flexibility and adjust spacing for better visual consistency.

Layout improvements:

* Added `mainAxisAlignment: MainAxisAlignment.spaceBetween` to a `Row` widget to ensure even spacing between its child elements. (`frontend/flutter_app/lib/components/tasks/task_group_page.dart`)
* Replaced a `Row` widget with a `Wrap` widget to handle horizontal and vertical spacing more flexibly. (`frontend/flutter_app/lib/components/tasks/task_group_page.dart`)

Styling adjustments:

* Adjusted the horizontal padding of the collection count badge from 10 to 8 for better alignment. (`frontend/flutter_app/lib/components/tasks/task_group_page.dart`)
* Increased the width of a `SizedBox` from 20 to 24 to provide more space between elements. (`frontend/flutter_app/lib/components/tasks/task_group_page.dart`)…oved UI, including a responsive wrap layout and refined sizing for elements.